### PR TITLE
2-AMIの更新を無視する

### DIFF
--- a/terraform/modules/environment/gitlab-runner-ec2/ec2.tf
+++ b/terraform/modules/environment/gitlab-runner-ec2/ec2.tf
@@ -94,5 +94,9 @@ resource "aws_instance" "gitlab_runner" {
   }
 
   key_name = var.ec2_key_name
+
+  lifecycle {
+    ignore_changes = [ami]
+  }
 }
 

--- a/terraform/modules/environment/self-host-gitlab/ec2.tf
+++ b/terraform/modules/environment/self-host-gitlab/ec2.tf
@@ -35,5 +35,9 @@ resource "aws_instance" "gitlab" {
   }
 
   key_name = var.ec2_key_name
+
+  lifecycle {
+    ignore_changes = [ami]
+  }
 }
 


### PR DESCRIPTION
Close #2 

GitLabサーバおよびGitLab runnerのAMIが構築時よりも最新のものが増えても変更を無視する様にしました。