### PR TITLE
#22 ドキュメント更新

### DIFF
--- a/documents/cicd.md
+++ b/documents/cicd.md
@@ -27,7 +27,7 @@
 
 - [kaniko](https://docs.gitlab.com/ee/ci/docker/using_kaniko.html)を使用し、レポジトリのルートにあるdockerfileをbuildする
 - buildしたimageは以下のタグを付与しECRにプッシュする
-  - <ECRホスト名>/<PJ-NAME-APP-NAME>:latest
+  - `<ECRホスト名>/<PJ-NAME-APP-NAME>:latest`
 - このパイプラインは`master`ブランチに対する変更時に実行する
 - パイプラインは`<PJ-NAME>`のタグがついたrunnerで実行する
 


### PR DESCRIPTION
Closes #22 

`<ECRホスト名>/<PJ-NAME-APP-NAME>:latest`がGithub上では「<ECRホスト名>/<PJ-NAME-APP-NAME>:latest」と表示されてしまうため、バッククォートで囲むよう修正